### PR TITLE
Fix an issue where selecting column names require current schema on pgsql

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -136,6 +136,8 @@ func (db *DB) dataTypes(table string) ([]*ColumnInfo, error) {
 
 	if db.dbType == DatabaseDriverMysql {
 		query += " AND table_schema = Database()"
+	} else if db.dbType == DatabaseDriverPostgres {
+		query += " AND table_schema = CURRENT_SCHEMA()"
 	}
 
 	var v []*ColumnInfo

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -354,9 +354,7 @@ func (db *DB) primaryKeys(tableName string) ([]string, error) {
 		AND 
 			TABLE_NAME = ?
 		AND
-			COLUMN_KEY = 'PRI'
-		ORDER BY
-			COLUMN_NAME`
+			COLUMN_KEY = 'PRI'`
 
 		err := db.sqlDB.Select(&pks, query, tableName)
 		if err != nil {
@@ -391,9 +389,7 @@ func (db *DB) primaryKeys(tableName string) ([]string, error) {
 		AND
 			pg_attribute.attnum = any(pg_index.indkey)
 		AND
-			indisprimary
-		ORDER BY
-			pg_attribute.attname`
+			indisprimary`
 		err = db.sqlDB.Select(&pks, query, strings.Join([]string{currentSchema, tableName}, "."))
 		if err != nil {
 			return nil, err

--- a/internal/testlib/docker-compose.yml
+++ b/internal/testlib/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       timeout: 10s
       retries: 3
   mysql:
-    image: "mysql:5.7"
+    image: "mysql:8"
     restart: always
     ports:
       - "3316:3306"


### PR DESCRIPTION

#### Summary
We need to select from current schema in postgres. 

@agnivade I'm not sure whether this is directly related to current failure happening in your server PR. But it looks like this was a subtle bug. On my local test, I was getting the same failure as your PR before this change. Now there is another issue about `Reactions` table is getting sorted differently. I'll look into that.

